### PR TITLE
feat: Add configurable timeout seconds setting, move to settings.ts

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,7 +1,6 @@
 import { App, MarkdownView, Plugin, PluginSettingTab, Setting, debounce } from 'obsidian';
 import {DEFAULT_SETTINGS, BudgetPluginSettings, BudgetSettings} from "./settings";
 
-
 export default class BudgetPlugin extends Plugin {
 	settings: BudgetPluginSettings;
 
@@ -36,38 +35,40 @@ export default class BudgetPlugin extends Plugin {
 			}
 			let classname = document.activeElement.className
 			let placeholder = document.activeElement.getAttribute('placeholder')
-			if(placeholder) {
+			if(placeholder === 'Type to start search...') {
 				return
 			}
-			//if(classname === 'view-header-title') {
-			//	return
-			//}
-			if(classname.includes('markdown-preview-view')){
-				if(activeView.getMode() === 'preview'){
-					let viewstate = activeView.leaf.getViewState()
-					viewstate.state.mode = 'source'
-					activeView.leaf.setViewState(viewstate)
-					activeView.editor.focus();
-					if(cursorpos)  {
-						activeView.editor.setCursor({ line: cursorpos.line, ch: cursorpos.ch });
-					} else {
-						activeView.editor.setCursor(activeView.editor.lastLine());
-					}
-				}}
+			if(classname === 'prompt-input' || classname === 'view-header-title') {
+				return
+			}
+			if(activeView.getMode() === 'preview'){
+				let viewstate = activeView.leaf.getViewState()
+				viewstate.state.mode = 'source'
+				activeView.leaf.setViewState(viewstate)
+    		activeView.editor.focus();
+				if(cursorpos) {
+					activeView.editor.setCursor({ line: cursorpos.line, ch: cursorpos.ch });
+				} else {
+					activeView.editor.setCursor(activeView.editor.lastLine());
+				}
+			}
 		});
 		let cursorpos: any
 		// Settings takes number of seconds, debounce takes ms
 		const timeout = Number(this.settings.previewModeSwitchDelay) * 1000;
 		let debouncef = debounce(doneTyping, timeout, true)
 
+		this.registerDomEvent(document, 'mousedown', (evt: MouseEvent) => {
+		});
+
+		this.registerDomEvent(document, 'mouseup', (evt: MouseEvent) => {
+			debouncef()
+		});
+
 		this.registerDomEvent(document, 'keyup', (evt: KeyboardEvent) => {
 			if(evt.key === 'Control' || evt.key === 'Alt' || evt.key === 'Shift' || evt.key === 'Meta') {
 				return;
 			}
-			debouncef()
-		});
-
-		this.registerDomEvent(document, 'mouseup', (evt: MouseEvent) => {
 			debouncef()
 		});
 	}

--- a/main.ts
+++ b/main.ts
@@ -1,18 +1,14 @@
 import { App, MarkdownView, Plugin, PluginSettingTab, Setting, debounce } from 'obsidian';
+import {DEFAULT_SETTINGS, BudgetPluginSettings, BudgetSettings} from "./settings";
 
-interface BudgetPluginSettings {
-	mySetting: string;
-}
-
-const DEFAULT_SETTINGS: BudgetPluginSettings = {
-	mySetting: 'default'
-}
 
 export default class BudgetPlugin extends Plugin {
 	settings: BudgetPluginSettings;
 
 	async onload() {
 		await this.loadSettings();
+		this.addSettingTab(new BudgetSettings(this.app, this));
+
 		const self = this;
 
 		function doneTyping() {
@@ -60,7 +56,9 @@ export default class BudgetPlugin extends Plugin {
 				}}
 		});
 		let cursorpos: any
-		let debouncef = debounce(doneTyping, 2000, true)
+		// Settings takes number of seconds, debounce takes ms
+		const timeout = Number(this.settings.previewModeSwitchDelay) * 1000;
+		let debouncef = debounce(doneTyping, timeout, true)
 
 		this.registerDomEvent(document, 'keyup', (evt: KeyboardEvent) => {
 			if(evt.key === 'Control' || evt.key === 'Alt' || evt.key === 'Shift' || evt.key === 'Meta') {

--- a/settings.ts
+++ b/settings.ts
@@ -1,0 +1,39 @@
+import {App, PluginSettingTab, Setting} from "obsidian";
+import BudgetPlugin from './main'
+
+export interface BudgetPluginSettings {
+	previewModeSwitchDelay: string;
+}
+
+export const DEFAULT_SETTINGS: BudgetPluginSettings = {
+	previewModeSwitchDelay: '3',
+}
+
+export class BudgetSettings extends PluginSettingTab {
+    plugin: BudgetPlugin;
+
+	constructor(app: App, plugin: BudgetPlugin) {
+		super(app, plugin);
+		this.plugin = plugin;
+	}
+
+    display(): void {
+        const { containerEl } = this;
+
+		containerEl.empty();
+
+		containerEl.createEl('h2', {text: 'Link Favicons'});
+
+    new Setting(containerEl)
+        .setName('Preview Mode Switch Delay')
+        .setDesc('The number of seconds of inaction before the file is shown in preview mode. Must be a number.')
+        .addText(text => text
+            .setValue(this.plugin.settings.previewModeSwitchDelay)
+            .setPlaceholder('3')
+            .onChange(async (value) => {
+                this.plugin.settings.previewModeSwitchDelay = value;
+                await this.plugin.saveSettings();
+                
+            }));
+    }
+}


### PR DESCRIPTION
This makes the timeout delay for debounce configurable.

* Moved settings to `settings.ts`
* Created settings `display()` method
* Created setting for "Preview Mode Switch Delay"

I wanted to enforce the entering of actual numbers in the settings but seems there's no real validation. 